### PR TITLE
Ensure dup() allocates new array in Extra field

### DIFF
--- a/pkg/yang/entry.go
+++ b/pkg/yang/entry.go
@@ -1268,7 +1268,7 @@ func (e *Entry) ApplyDeviate(deviateOpts ...DeviateOpt) []error {
 								}
 							}
 							if !found {
-								appendErr(fmt.Errorf("must statement marked for deletion not found [%s]", mustDelete.Name))
+								appendErr(fmt.Errorf("must statement [%s] on path [%s] marked for deletion but was not found", mustDelete.Name, d.DeviatedPath))
 							}
 							devNodeMust := deviatedNode.Extra["must"]
 							devNodeMust[idx] = devNodeMust[len(devNodeMust)-1]            // Swap with last element
@@ -1512,7 +1512,11 @@ func (e *Entry) dup() *Entry {
 
 	ne.Extra = make(map[string][]interface{})
 	for k, v := range e.Extra {
-		ne.Extra[k] = v
+		vc := make([]interface{}, len(v))
+		for i := range v {
+			vc[i] = v[i]
+		}
+		ne.Extra[k] = vc
 	}
 
 	return &ne


### PR DESCRIPTION
This modifies the dup() function to properly create a new slice for slices contained in the Extra map.
It also makes the error statement for not found must statements more verbose